### PR TITLE
画像投稿機能完成

### DIFF
--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Post;
-use App\Models\{Tag, Visibility};
+use App\Models\{Tag, Visibility, PostAttachment};
 use App\Http\Requests\PostStoreRequest;
 use App\Http\Requests\PostUpdateRequest;
 use App\Models\User; // 追加
+use Illuminate\Support\Facades\Storage;
 
 class PostController extends Controller
 {
@@ -17,7 +18,7 @@ class PostController extends Controller
     {
         // 公開投稿のみ取得したい場合は whereHas を利用（必要に応じて調整）
         $posts = Post::query()
-            ->with(['user:id,name', 'visibility:id,code'])
+            ->with(['user:id,name', 'visibility:id,code', 'attachment']) // 添付も取得
             ->latest('id')
             ->paginate(10);
 
@@ -41,23 +42,27 @@ class PostController extends Controller
     {
         $data = $request->validated();
 
-        // 認証導入後: 必ず auth()->id() を使う
-        $userId = auth()->id();
-
-        // 未導入の暫定対応：既存ユーザーのIDを利用（なければエラーに）
+        // ユーザーID（認証導入前の暫定）
+        $userId = auth()->id() ?: \App\Models\User::query()->value('id');
         if (!$userId) {
-            $userId = User::query()->value('id'); // 最初のユーザーID
-            if (!$userId) {
-                return back()->withInput()->with('error', 'ユーザーが存在しないため投稿できません。先にユーザーを作成してください。');
-            }
+            return back()->withInput()->with('error', 'ユーザーが存在しないため投稿できません。');
         }
-
         $data['user_id'] = $userId;
 
         $post = Post::create($data);
 
         if (isset($data['tags'])) {
             $post->tags()->sync($data['tags']);
+        }
+
+        // 画像保存（任意）
+        if ($request->hasFile('image')) {
+            $path = $request->file('image')->store('attachments', 'public');
+            $post->attachment()->create([
+                'path' => $path,
+                'mime' => $request->file('image')->getClientMimeType(),
+                'size' => $request->file('image')->getSize(),
+            ]);
         }
 
         return redirect()->route('posts.show', $post)->with('status', 'created');
@@ -74,7 +79,7 @@ class PostController extends Controller
             // abort(404);
         }
 
-        $post->loadMissing(['user:id,name', 'visibility:id,code', 'tags:id,name']);
+        $post->loadMissing(['user:id,name', 'visibility:id,code', 'tags:id,name', 'attachment']);
         return view('posts.show', compact('post'));
     }
 
@@ -83,7 +88,7 @@ class PostController extends Controller
      */
     public function edit(Post $post)
     {
-        $post->loadMissing('tags');
+        $post->loadMissing(['tags', 'attachment']);
         $visibilities = Visibility::select('id','code')->get();
         $tags = Tag::orderBy('name')->get(['id','name']);
         return view('posts.edit', compact('post','visibilities','tags'));
@@ -102,6 +107,23 @@ class PostController extends Controller
             $post->tags()->sync($data['tags'] ?? []);
         }
 
+        // 新しい画像があれば置き換え
+        if ($request->hasFile('image')) {
+            // 旧ファイル削除
+            if ($post->attachment && $post->attachment->path) {
+                Storage::disk('public')->delete($post->attachment->path);
+            }
+            $path = $request->file('image')->store('attachments', 'public');
+            $post->attachment()->updateOrCreate(
+                [], // hasOne なので条件なしで1件を更新/作成
+                [
+                    'path' => $path,
+                    'mime' => $request->file('image')->getClientMimeType(),
+                    'size' => $request->file('image')->getSize(),
+                ]
+            );
+        }
+
         return redirect()->route('posts.show', $post)->with('status', 'updated');
     }
 
@@ -110,7 +132,12 @@ class PostController extends Controller
      */
     public function destroy(Post $post)
     {
+        // 添付ファイルの物理削除（FKでレコードは削除される）
+        if ($post->attachment && $post->attachment->path) {
+            Storage::disk('public')->delete($post->attachment->path);
+        }
         $post->delete();
+
         return redirect()->route('posts.index')->with('status', 'deleted');
     }
 }

--- a/src/app/Http/Requests/PostStoreRequest.php
+++ b/src/app/Http/Requests/PostStoreRequest.php
@@ -18,6 +18,7 @@ class PostStoreRequest extends FormRequest
             'visibility_id' => ['required', 'integer', 'exists:visibilities,id'],
             'tags' => ['sometimes', 'array'],
             'tags.*' => ['integer', 'exists:tags,id'],
+            'image' => ['nullable', 'image', 'mimes:jpeg,png', 'max:2048'],
         ];
     }
 

--- a/src/app/Http/Requests/PostUpdateRequest.php
+++ b/src/app/Http/Requests/PostUpdateRequest.php
@@ -18,6 +18,7 @@ class PostUpdateRequest extends FormRequest
             'visibility_id' => ['sometimes', 'required', 'integer', 'exists:visibilities,id'],
             'tags' => ['sometimes', 'array'],
             'tags.*' => ['integer', 'exists:tags,id'],
+            'image' => ['sometimes', 'nullable', 'image', 'mimes:jpeg,png', 'max:2048'],
         ];
     }
 

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\{BelongsTo, BelongsToMany};
+use Illuminate\Database\Eloquent\Relations\{BelongsTo, BelongsToMany, HasOne};
 
 class Post extends Model
 {
@@ -15,5 +15,10 @@ class Post extends Model
     public function tags(): BelongsToMany
     {
         return $this->belongsToMany(Tag::class, 'post_tags');
+    }
+
+    public function attachment(): HasOne
+    {
+        return $this->hasOne(PostAttachment::class);
     }
 }

--- a/src/app/Models/PostAttachment.php
+++ b/src/app/Models/PostAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostAttachment extends Model
+{
+    protected $fillable = ['post_id', 'path', 'mime', 'size'];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/src/database/migrations/2025_09_02_120000_create_post_attachments_table.php
+++ b/src/database/migrations/2025_09_02_120000_create_post_attachments_table.php
@@ -1,0 +1,26 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('post_attachments', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->unsignedBigInteger('post_id');
+            $t->string('path', 255);
+            $t->string('mime', 64);
+            $t->unsignedInteger('size');
+            $t->timestamps();
+
+            $t->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $t->index('post_id', 'idx_post_attachments_post');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_attachments');
+    }
+};

--- a/src/resources/views/posts/create.blade.php
+++ b/src/resources/views/posts/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <h1>Create Post</h1>
 
-<form method="POST" action="{{ route('posts.store') }}">
+<form method="POST" action="{{ route('posts.store') }}" enctype="multipart/form-data">
   @csrf
 
   <div class="field">
@@ -36,6 +36,12 @@
     @error('tags.*') <div class="error-text">{{ $message }}</div> @enderror
   </div>
   @endif
+
+  <div class="field">
+    <label for="image">画像（JPEG/PNG, 最大2MB）</label><br>
+    <input type="file" id="image" name="image" accept="image/jpeg,image/png">
+    @error('image') <div class="error-text">{{ $message }}</div> @enderror
+  </div>
 
   <button type="submit">保存</button>
   <a href="{{ route('posts.index') }}">キャンセル</a>

--- a/src/resources/views/posts/edit.blade.php
+++ b/src/resources/views/posts/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <h1>Edit Post</h1>
 
-<form method="POST" action="{{ route('posts.update', $post) }}">
+<form method="POST" action="{{ route('posts.update', $post) }}" enctype="multipart/form-data">
   @csrf
   @method('PUT')
 
@@ -38,6 +38,18 @@
     @error('tags.*') <div class="error-text">{{ $message }}</div> @enderror
   </div>
   @endif
+
+  <div class="field">
+    <label for="image">画像（差し替え）</label><br>
+    <input type="file" id="image" name="image" accept="image/jpeg,image/png">
+    @error('image') <div class="error-text">{{ $message }}</div> @enderror
+
+    @if($post->attachment)
+      <div style="margin-top:8px">
+        <img src="{{ asset('storage/'.$post->attachment->path) }}" alt="" style="width:160px;height:160px;object-fit:cover;border:1px solid #ddd;border-radius:8px;">
+      </div>
+    @endif
+  </div>
 
   <button type="submit">更新</button>
   <a href="{{ route('posts.show', $post) }}">戻る</a>

--- a/src/resources/views/posts/index.blade.php
+++ b/src/resources/views/posts/index.blade.php
@@ -6,13 +6,18 @@
 <h1>Posts</h1>
 
 @foreach ($posts as $post)
-  <article class="card">
-    <p>{{ Str::limit($post->body, 140) }}</p>
-    <div class="muted">
-      by {{ $post->user->name }} ・ visibility: {{ $post->visibility->code }}
-    </div>
-    <div style="margin-top:8px">
-      <a href="{{ route('posts.show', $post) }}">詳細を見る →</a>
+  <article class="card" style="display:flex;gap:12px;align-items:flex-start;">
+    @if($post->attachment)
+      <img src="{{ asset('storage/'.$post->attachment->path) }}" alt="" style="width:96px;height:96px;object-fit:cover;border:1px solid #ddd;border-radius:8px;">
+    @endif
+    <div style="flex:1">
+      <p>{{ Str::limit($post->body, 140) }}</p>
+      <div class="muted">
+        by {{ $post->user->name ?? 'Unknown' }} ・ {{ $post->visibility->code ?? '-' }}
+      </div>
+      <div style="margin-top:8px">
+        <a href="{{ route('posts.show', $post) }}">詳細</a>
+      </div>
     </div>
   </article>
 @endforeach

--- a/src/resources/views/posts/show.blade.php
+++ b/src/resources/views/posts/show.blade.php
@@ -5,7 +5,14 @@
 
 <article class="card">
   <div class="muted">by {{ $post->user->name }} ・ {{ $post->visibility->code }}</div>
-  <p style="white-space:pre-wrap; margin-top:8px">{{ $post->body }}</p>
+
+  @if($post->attachment)
+    <div style="margin-top:12px">
+      <img src="{{ asset('storage/'.$post->attachment->path) }}" alt="" style="max-width:100%;height:auto;border:1px solid #ddd;border-radius:8px;">
+    </div>
+  @endif
+
+  <p style="white-space:pre-wrap; margin-top:12px">{{ $post->body }}</p>
 
   @if($post->tags->isNotEmpty())
     <div style="margin-top:12px">
@@ -16,7 +23,7 @@
   @endif
 
   <div class="muted" style="margin-top:12px">
-    Likes: {{ $post->liked_by_users_count }}
+    Likes: {{ $post->liked_by_users_count ?? 0 }}
   </div>
 </article>
 @endsection


### PR DESCRIPTION
# feat: 画像添付の下地を実装（post_attachments／保存〜表示の最小動線）

ブランチ: `feature/post-attachments-basic`

## 概要
投稿に画像を1枚添付できる下地を実装。作成/編集フォームで画像をアップロードし、publicストレージに保存、一覧・詳細でサムネ/画像を表示します。既存CRUDと両立し、認証導入前でも動作します。

## 変更内容
- Migration: `post_attachments` テーブルを追加（post_id, path, mime, size, timestamps）
- Model: `App\Models\PostAttachment` を新規追加、`Post` に `attachment()`（hasOne）を追加
- Validation: `PostStoreRequest` / `PostUpdateRequest` に画像バリデを追加
  - `image|mimes:jpeg,png|max:2048`（Update は `sometimes|nullable`）
- Controller: `PostController@store/update/destroy/index/show/edit` を拡張
  - 画像の保存/置換/削除（`Storage::disk('public')`）
  - 一覧・詳細・編集で `attachment` を eager load
- Blade:
  - `create/edit` に `<input type="file" name="image">` を追加（`enctype="multipart/form-data"`）
  - `index/show` にサムネ/画像表示を追加
- ストレージ公開: `storage:link` 前提（public/storage → storage/app/public）

## 動作イメージ
- 作成: フォームで画像選択→保存→詳細で画像表示
- 更新: 新しい画像で差し替え→旧ファイルは削除
- 一覧: ある場合のみサムネ表示（96x96, object-fit: cover）

## 実行手順
```bash
# マイグレーション（追加のみ）
php src/artisan migrate

# 初回のみ（public/storage のシンボリックリンク）
php src/artisan storage:link
```

## 確認手順
1) /posts/create を開く
   - 本文と公開範囲を入力、画像（JPEG/PNG, ≤2MB）を選択→保存
   - 詳細に画像が表示されること
2) /posts/{id}/edit で別の画像に差し替え→旧画像が削除されていること
3) /posts 一覧でサムネが表示されること
4) バリデーション
   - 2MB超や非JPEG/PNGでエラー（422→PRGでフォームに戻りエラー表示）

## セキュリティ/運用メモ
- 検証は MIME ベース（`image` ルール）＋拡張子を限定（jpeg,png）
- 公開ディスクに保存（XSS/実行ファイル混入を防ぐため画像以外を拒否）
- 置換時に旧ファイルを物理削除（ストレージ肥大防止）
- 今回は1投稿1枚（hasOne）。将来的に複数対応は hasMany とピボット順序/並びカラム追加で拡張可能

## 影響範囲
- モデル/コントローラ/ビューの一部を拡張（既存のCRUD・一覧/詳細は後方互換）
- DB に `post_attachments` が追加されます

## ロールバック
```bash
# 直前のマイグレーションのみ取り消し（post_attachments）
php src/artisan migrate:rollback --step=1
```

## DoD
- [x] 画像アップ→表示の最小動線が成立
- [x] `post_attachments` 追加のみで既存データを壊さない
- [x] `storage:link` 後、一覧/詳細で添付を読み込み可能
- [x] XSS/実行ファイル混入の注意点を Notion に記載（MIME検証・publicディスク・旧ファイル削除）

## 補足（フォローアップ候補）
- 縮小/サムネ生成（Intervention/Image など）と EXIF の自動回転
- 複数枚対応と並び順
- S3 等