### PR TITLE
いいねAJAX対応

### DIFF
--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -18,7 +18,8 @@ class PostController extends Controller
     {
         // 公開投稿のみ取得したい場合は whereHas を利用（必要に応じて調整）
         $posts = Post::query()
-            ->with(['user:id,name', 'visibility:id,code', 'attachment']) // 添付も取得
+            ->with(['user:id,name','visibility:id,code','attachment'])
+            ->withCount('likedByUsers') // ← いいね数
             ->latest('id')
             ->paginate(10);
 
@@ -79,7 +80,8 @@ class PostController extends Controller
             // abort(404);
         }
 
-        $post->loadMissing(['user:id,name', 'visibility:id,code', 'tags:id,name', 'attachment']);
+        $post->loadMissing(['user:id,name','visibility:id,code','tags:id,name','attachment'])
+             ->loadCount('likedByUsers');
         return view('posts.show', compact('post'));
     }
 

--- a/src/app/Http/Controllers/PostLikeController.php
+++ b/src/app/Http/Controllers/PostLikeController.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class PostLikeController extends Controller
+{
+    public function __invoke(Request $request, Post $post): JsonResponse
+    {
+        // 認証前の擬似ユーザー（先頭のユーザーを使用）
+        $userId = auth()->id() ?: User::query()->value('id');
+        if (!$userId) {
+            return response()->json(['message' => 'ユーザーが存在しません'], 401);
+        }
+
+        $exists = DB::table('likes')->where([
+            'user_id' => $userId,
+            'post_id' => $post->id,
+        ])->exists();
+
+        if ($exists) {
+            DB::table('likes')->where([
+                'user_id' => $userId,
+                'post_id' => $post->id,
+            ])->delete();
+            $liked = false;
+        } else {
+            DB::table('likes')->insert([
+                'user_id' => $userId,
+                'post_id' => $post->id,
+                'created_at' => now(),
+            ]);
+            $liked = true;
+        }
+
+        $count = DB::table('likes')->where('post_id', $post->id)->count();
+
+        return response()->json(['liked' => $liked, 'count' => $count]);
+    }
+}

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -21,4 +21,9 @@ class Post extends Model
     {
         return $this->hasOne(PostAttachment::class);
     }
+
+    public function likedByUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'likes', 'post_id', 'user_id');
+    }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class User extends Authenticatable
 {
@@ -48,6 +49,6 @@ class User extends Authenticatable
 
     public function likedPosts(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\Post::class, 'likes');
+        return $this->belongsToMany(Post::class, 'likes', 'user_id', 'post_id');
     }
 }

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>SNS Study</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <style>
     body{font-family: system-ui, sans-serif; line-height:1.6; padding:24px; max-width:820px; margin:0 auto;}
     .card{border:1px solid #ddd; border-radius:12px; padding:16px; margin:12px 0;}
@@ -12,8 +13,7 @@
     .flash.success{background:#e6ffed; color:#036400; border:1px solid #b7ebc0;}
     .flash.error{background:#fff1f0; color:#a8071a; border:1px solid #ffa39e;}
     .error-text{color:#a8071a; font-size:0.9em;}
-    a{color:#0b5ed7; text-decoration:none} a:hover{text-decoration:underline}
-    .field{margin:12px 0;}
+    .like-btn.liked{color:#d63384;}
   </style>
 </head>
 <body>
@@ -36,5 +36,48 @@
 
     @yield('content')
   </div>
+
+  <script>
+  (() => {
+    const tokenEl = document.querySelector('meta[name="csrf-token"]');
+    const csrf = tokenEl ? tokenEl.content : '';
+
+    async function toggleLike(btn) {
+      const url = btn.dataset.url;
+      const postId = btn.dataset.postId;
+      btn.disabled = true;
+      try {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json',
+            'X-CSRF-TOKEN': csrf
+          }
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.message || 'エラーが発生しました');
+
+        const countEl = document.querySelector(`.like-count[data-post-id="${postId}"]`);
+        if (countEl) countEl.textContent = data.count ?? 0;
+
+        const liked = !!data.liked;
+        btn.classList.toggle('liked', liked);
+        btn.textContent = liked ? 'いいね解除' : 'いいね';
+      } catch (e) {
+        alert(e.message || '通信エラー');
+      } finally {
+        btn.disabled = false;
+      }
+    }
+
+    document.addEventListener('click', (e) => {
+      const btn = e.target.closest('.like-btn');
+      if (btn) {
+        e.preventDefault();
+        toggleLike(btn);
+      }
+    });
+  })();
+  </script>
 </body>
 </html>

--- a/src/resources/views/posts/index.blade.php
+++ b/src/resources/views/posts/index.blade.php
@@ -12,10 +12,11 @@
     @endif
     <div style="flex:1">
       <p>{{ Str::limit($post->body, 140) }}</p>
-      <div class="muted">
-        by {{ $post->user->name ?? 'Unknown' }} ・ {{ $post->visibility->code ?? '-' }}
-      </div>
-      <div style="margin-top:8px">
+      <div class="muted">by {{ $post->user->name ?? 'Unknown' }} ・ {{ $post->visibility->code ?? '-' }}</div>
+
+      <div style="margin-top:8px; display:flex; gap:8px; align-items:center;">
+        <button class="like-btn" data-post-id="{{ $post->id }}" data-url="{{ route('posts.like', $post) }}">いいね</button>
+        <span class="muted">Likes: <span class="like-count" data-post-id="{{ $post->id }}">{{ $post->liked_by_users_count ?? 0 }}</span></span>
         <a href="{{ route('posts.show', $post) }}">詳細</a>
       </div>
     </div>

--- a/src/resources/views/posts/show.blade.php
+++ b/src/resources/views/posts/show.blade.php
@@ -22,8 +22,9 @@
     </div>
   @endif
 
-  <div class="muted" style="margin-top:12px">
-    Likes: {{ $post->liked_by_users_count ?? 0 }}
+  <div class="muted" style="margin-top:12px; display:flex; gap:8px; align-items:center;">
+    <button class="like-btn" data-post-id="{{ $post->id }}" data-url="{{ route('posts.like', $post) }}">いいね</button>
+    Likes: <span class="like-count" data-post-id="{{ $post->id }}">{{ $post->liked_by_users_count ?? 0 }}</span>
   </div>
 </article>
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\PostLikeController;
 
 Route::get('/', fn () => redirect()->route('posts.index'));
 
@@ -16,3 +17,5 @@ Route::resource('posts', PostController::class)
         'edit' => 'posts.edit',
         'update' => 'posts.update',
     ]);
+
+Route::post('posts/{post}/like', PostLikeController::class)->name('posts.like');


### PR DESCRIPTION
# feat: いいねトグル（AJAX）を実装（擬似ユーザー対応）

ブランチ: `feature/like-toggle-ajax`

## 概要
投稿詳細・一覧で「いいね」を即時トグルできるようにしました。非同期（fetch + CSRF）で `{ liked, count }` を受け取り、ボタン表示とカウントを更新します。認証未導入環境では既存ユーザーの先頭を擬似的に利用します。

## 変更内容
- ルート
  - `POST /posts/{post}/like` を追加（JSON 返却, name: `posts.like`）
- Controller
  - `PostLikeController` を追加（`__invoke`）
    - 既存ユーザーの先頭 or `auth()->id()` を使用して likes をトグル
    - レスポンス: `{ liked: bool, count: int }`
- Model
  - `Post::likedByUsers()` を追加（BelongsToMany, pivot: `likes`）
  - `User::likedPosts()` を追加（任意、参照用）
- PostController
  - 一覧・詳細で `withCount('likedByUsers')` を追加（いいね数表示）
- Blade
  - 一覧・詳細に「いいね」ボタンとカウント表示を追加
  - ボタンに `data-url`/`data-post-id` を付与
- Layout
  - `<meta name="csrf-token">` を追加
  - シンプルな `fetch` 実装（クリックで即時トグル、カウント更新、失敗時 alert）
  - ボタン見た目用の `.like-btn.liked` スタイルを追加

## 動作確認手順
1) 事前準備
   - `likes` テーブルが存在しない場合はマイグレーションを実行
     - `php src/artisan migrate`
   - CSRF メタが head に出ていることを確認（`layouts/app.blade.php`）
2) サーバ起動
   - `php -S 127.0.0.1:8000 -t src/public`
3) 確認
   - 一覧/詳細で「いいね」ボタンをクリック
   - 即座にカウントが増減すること
   - DevTools Network で `POST /posts/{id}/like` が 200、レスポンスが `{ liked, count }`、リクエストヘッダに `X-CSRF-TOKEN` が付与されていること

## 仕様補足
- 認証未導入のため、擬似的に既存ユーザーの先頭IDを利用（未存在時は 401 JSON を返却）
- 初期の「自分がいいね済みか」表示は未実装（クリック以降はボタンがトグル表示）

## DoD
- [x] クリックで即時カウント更新
- [x] CSRF ヘッダ付き fetch による POST
- [x] エラー時は alert 表示（暫定）

## 今後
- 認証導入後は擬似ユーザーを削除し、`auth()->id()` 前提に変更
- 初期 liked 状態の反映、トースト通知、レート制限の導入