### PR TITLE
コメント機能実装

### DIFF
--- a/src/app/Http/Controllers/PostCommentController.php
+++ b/src/app/Http/Controllers/PostCommentController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Http\Requests\CommentStoreRequest;
+
+class PostCommentController extends Controller
+{
+    public function __invoke(CommentStoreRequest $request, Post $post)
+    {
+        $data = $request->validated();
+
+        // 認証未導入の暫定：先頭のユーザーを利用
+        $userId = auth()->id() ?: User::query()->value('id');
+        if (!$userId) {
+            return back()->withInput()->with('error', 'ユーザーが存在しないためコメントできません。');
+        }
+
+        $post->comments()->create([
+            'user_id' => $userId,
+            'body'    => $data['body'],
+        ]);
+
+        return back()->with('status', 'commented');
+    }
+}

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -80,8 +80,14 @@ class PostController extends Controller
             // abort(404);
         }
 
-        $post->loadMissing(['user:id,name','visibility:id,code','tags:id,name','attachment'])
-             ->loadCount('likedByUsers');
+        $post->loadMissing([
+            'user:id,name',
+            'visibility:id,code',
+            'tags:id,name',
+            'attachment',
+            'comments.user:id,name',
+        ])->loadCount('likedByUsers');
+
         return view('posts.show', compact('post'));
     }
 

--- a/src/app/Http/Requests/CommentStoreRequest.php
+++ b/src/app/Http/Requests/CommentStoreRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // 認証導入後に権限チェックへ
+    }
+
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:1000'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'body' => 'コメント',
+        ];
+    }
+}

--- a/src/app/Models/Comment.php
+++ b/src/app/Models/Comment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Comment extends Model
+{
+    protected $fillable = ['post_id', 'user_id', 'body'];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\{BelongsTo, BelongsToMany, HasOne};
+use Illuminate\Database\Eloquent\Relations\{BelongsTo, BelongsToMany, HasMany, HasOne};
 
 class Post extends Model
 {
@@ -25,5 +25,10 @@ class Post extends Model
     public function likedByUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'likes', 'post_id', 'user_id');
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class)->latest('id');
     }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -50,5 +51,10 @@ class User extends Authenticatable
     public function likedPosts(): BelongsToMany
     {
         return $this->belongsToMany(Post::class, 'likes', 'user_id', 'post_id');
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
     }
 }

--- a/src/database/migrations/2025_09_02_130000_create_comments_table.php
+++ b/src/database/migrations/2025_09_02_130000_create_comments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->unsignedBigInteger('post_id');
+            $t->unsignedBigInteger('user_id');
+            $t->string('body', 1000);
+            $t->timestamps();
+
+            $t->index(['post_id', 'created_at'], 'idx_comments_post_created');
+            $t->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $t->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/src/resources/views/posts/show.blade.php
+++ b/src/resources/views/posts/show.blade.php
@@ -27,4 +27,29 @@
     Likes: <span class="like-count" data-post-id="{{ $post->id }}">{{ $post->liked_by_users_count ?? 0 }}</span>
   </div>
 </article>
+
+<section class="card" style="margin-top:16px;">
+  <h3>コメント</h3>
+
+  @forelse($post->comments as $comment)
+    <div style="border-top:1px solid #eee; padding-top:8px; margin-top:8px;">
+      <div class="muted">by {{ $comment->user->name }} ・ {{ $comment->created_at->diffForHumans() }}</div>
+      <div style="white-space:pre-wrap;">{{ $comment->body }}</div>
+    </div>
+  @empty
+    <div class="muted">最初のコメントを書きましょう。</div>
+  @endforelse
+</section>
+
+<section class="card" style="margin-top:12px;">
+  <h3>コメントを書く</h3>
+  <form method="POST" action="{{ route('posts.comments.store', $post) }}">
+    @csrf
+    <div class="field">
+      <textarea name="body" rows="4" placeholder="コメントを入力...">{{ old('body') }}</textarea>
+      @error('body') <div class="error-text">{{ $message }}</div> @enderror
+    </div>
+    <button type="submit">送信</button>
+  </form>
+</section>
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -3,19 +3,12 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\PostLikeController;
+use App\Http\Controllers\PostCommentController;
 
 Route::get('/', fn () => redirect()->route('posts.index'));
 
-Route::resource('posts', PostController::class)
-    ->only(['index', 'show', 'create', 'store', 'edit', 'update', 'destroy'])
-    ->names([
-        'index' => 'posts.index',
-        'show'  => 'posts.show',
-        'destroy' => 'posts.destroy',
-        'create' => 'posts.create',
-        'store' => 'posts.store',
-        'edit' => 'posts.edit',
-        'update' => 'posts.update',
-    ]);
+Route::resource('posts', PostController::class);
 
 Route::post('posts/{post}/like', PostLikeController::class)->name('posts.like');
+
+Route::post('posts/{post}/comments', PostCommentController::class)->name('posts.comments.store');


### PR DESCRIPTION
```markdown
# feat: コメント機能（単階層）を実装

ブランチ: `feature/comments-basic`

## 概要
投稿詳細ページにコメントの投稿・表示（単階層）を追加しました。未ログイン環境では暫定的に既存ユーザーの先頭を擬似ユーザーとして使用します。

## 変更点
- Migration
  - `comments` テーブルを追加（post_id, user_id, body, timestamps、FK・インデックス）
- Model
  - `App\Models\Comment` を新規追加（Post/User への BelongsTo）
  - `Post` に `comments()`（HasMany, 最新順）を追加
  - `User` に `comments()`（HasMany）を追加
- FormRequest
  - `CommentStoreRequest`（`body: required|string|max:1000`）
- Controller
  - `PostCommentController`（`__invoke`）
    - 擬似ユーザーで作成し、PRGで戻りフラッシュ `commented` を設定
  - `PostController@show` で `comments.user` を Eager Load
- Route
  - `POST /posts/{post}/comments`（name: `posts.comments.store`）
- View
  - 詳細画面にコメント一覧と投稿フォームを追加
  - バリデーションエラー表示と `old('body')` 入力保持に対応

## 動作確認
1) マイグレーション
```bash
php src/artisan migrate
```
2) ユーザーが存在しない場合は作成（暫定）
```bash
php src/artisan tinker
```
```php
\App\Models\User::factory()->create();
exit
```
3) ブラウザで任意の投稿詳細へ
- 下部フォームからコメント投稿 → 一覧に即表示、フラッシュ `commented`
- `body` 空で送信 → フォームにエラー表示・入力保持

## DoD
- [x] 正しく投稿・表示できる
- [x] フォーム→検証→保存のフローを Notion に追記（単階層、PRG、エラー時入力保持）

## 互換性
- 既存機能への破壊的変更なし（comments の追加のみ）
- 認証導入後は擬似ユーザー利用を廃止予定（`auth()->id()` 固定へ）

## ロールバック
```bash
php src/artisan migrate:rollback --step=1
```
```