### PR TITLE
フォロー機能実装

### DIFF
--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -72,7 +72,7 @@ class PostController extends Controller
     /**
      * 詳細
      */
-    public function show(Post $post)
+    public function show(\App\Models\Post $post)
     {
         // 可視性の簡易チェック（認証導入後は Policy::view に集約）
         if ($post->visibility?->code !== 'public') {
@@ -87,6 +87,9 @@ class PostController extends Controller
             'attachment',
             'comments.user:id,name',
         ])->loadCount('likedByUsers');
+
+        // 著者ユーザーのフォロワー数
+        $post->user?->loadCount('followers');
 
         return view('posts.show', compact('post'));
     }

--- a/src/app/Http/Controllers/UserFollowController.php
+++ b/src/app/Http/Controllers/UserFollowController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class UserFollowController extends Controller
+{
+    public function __invoke(Request $request, User $user): JsonResponse
+    {
+        $followerId = auth()->id() ?: User::query()->value('id');
+        if (!$followerId) {
+            return response()->json(['message' => 'ユーザーが存在しません'], 401);
+        }
+
+        // 自分自身は不可
+        if ((int)$followerId === (int)$user->id) {
+            $count = DB::table('follows')->where('followee_id', $user->id)->count();
+            return response()->json(['following' => false, 'count' => $count], 400);
+        }
+
+        $exists = DB::table('follows')->where([
+            'follower_id' => $followerId,
+            'followee_id' => $user->id,
+        ])->exists();
+
+        if ($exists) {
+            DB::table('follows')->where([
+                'follower_id' => $followerId,
+                'followee_id' => $user->id,
+            ])->delete();
+            $following = false;
+        } else {
+            DB::table('follows')->insert([
+                'follower_id' => $followerId,
+                'followee_id' => $user->id,
+                'created_at'  => now(),
+            ]);
+            $following = true;
+        }
+
+        $count = DB::table('follows')->where('followee_id', $user->id)->count();
+
+        return response()->json(['following' => $following, 'count' => $count]);
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -2,12 +2,10 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\{BelongsToMany, HasMany};
 
 class User extends Authenticatable
 {
@@ -56,5 +54,15 @@ class User extends Authenticatable
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    public function followers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'follows', 'followee_id', 'follower_id');
+    }
+
+    public function followings(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'follows', 'follower_id', 'followee_id');
     }
 }

--- a/src/database/migrations/2025_09_02_140000_create_follows_table.php
+++ b/src/database/migrations/2025_09_02_140000_create_follows_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('follows', function (Blueprint $t) {
+            $t->unsignedBigInteger('follower_id');
+            $t->unsignedBigInteger('followee_id');
+            $t->timestamp('created_at')->useCurrent();
+
+            $t->primary(['follower_id','followee_id'], 'pk_follows');
+            $t->index('followee_id', 'idx_follows_followee');
+
+            $t->foreign('follower_id')->references('id')->on('users')->onDelete('cascade');
+            $t->foreign('followee_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('follows');
+    }
+};

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -14,6 +14,7 @@
     .flash.error{background:#fff1f0; color:#a8071a; border:1px solid #ffa39e;}
     .error-text{color:#a8071a; font-size:0.9em;}
     .like-btn.liked{color:#d63384;}
+    .follow-btn.following{color:#0b5ed7; font-weight:600;}
   </style>
 </head>
 <body>
@@ -39,43 +40,50 @@
 
   <script>
   (() => {
-    const tokenEl = document.querySelector('meta[name="csrf-token"]');
-    const csrf = tokenEl ? tokenEl.content : '';
+    const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
 
     async function toggleLike(btn) {
       const url = btn.dataset.url;
       const postId = btn.dataset.postId;
       btn.disabled = true;
       try {
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: {
-            'Accept': 'application/json',
-            'X-CSRF-TOKEN': csrf
-          }
-        });
+        const res = await fetch(url, { method: 'POST', headers: { 'Accept':'application/json', 'X-CSRF-TOKEN': csrf }});
         const data = await res.json().catch(() => ({}));
         if (!res.ok) throw new Error(data.message || 'エラーが発生しました');
 
-        const countEl = document.querySelector(`.like-count[data-post-id="${postId}"]`);
-        if (countEl) countEl.textContent = data.count ?? 0;
-
+        document.querySelector(`.like-count[data-post-id="${postId}"]`)?.replaceChildren(document.createTextNode(data.count ?? 0));
         const liked = !!data.liked;
         btn.classList.toggle('liked', liked);
         btn.textContent = liked ? 'いいね解除' : 'いいね';
       } catch (e) {
         alert(e.message || '通信エラー');
-      } finally {
-        btn.disabled = false;
-      }
+      } finally { btn.disabled = false; }
+    }
+
+    async function toggleFollow(btn) {
+      const url = btn.dataset.url;
+      const userId = btn.dataset.userId;
+      btn.disabled = true;
+      try {
+        const res = await fetch(url, { method: 'POST', headers: { 'Accept':'application/json', 'X-CSRF-TOKEN': csrf }});
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.message || 'エラーが発生しました');
+
+        document.querySelector(`.followers-count[data-user-id="${userId}"]`)?.replaceChildren(document.createTextNode(data.count ?? 0));
+        const following = !!data.following;
+        btn.classList.toggle('following', following);
+        btn.textContent = following ? 'フォロー解除' : 'フォローする';
+      } catch (e) {
+        alert(e.message || '通信エラー');
+      } finally { btn.disabled = false; }
     }
 
     document.addEventListener('click', (e) => {
-      const btn = e.target.closest('.like-btn');
-      if (btn) {
-        e.preventDefault();
-        toggleLike(btn);
-      }
+      const likeBtn = e.target.closest('.like-btn');
+      if (likeBtn) { e.preventDefault(); toggleLike(likeBtn); return; }
+
+      const followBtn = e.target.closest('.follow-btn');
+      if (followBtn) { e.preventDefault(); toggleFollow(followBtn); return; }
     });
   })();
   </script>

--- a/src/resources/views/posts/show.blade.php
+++ b/src/resources/views/posts/show.blade.php
@@ -4,7 +4,11 @@
 <p><a href="{{ route('posts.index') }}">← Back to Posts</a></p>
 
 <article class="card">
-  <div class="muted">by {{ $post->user->name }} ・ {{ $post->visibility->code }}</div>
+  <div class="muted" style="display:flex; gap:12px; align-items:center;">
+    <span>by {{ $post->user->name }} ・ {{ $post->visibility->code }}</span>
+    <button class="follow-btn" data-user-id="{{ $post->user->id }}" data-url="{{ route('users.follow', $post->user) }}">フォローする</button>
+    <span class="muted">Followers: <span class="followers-count" data-user-id="{{ $post->user->id }}">{{ $post->user->followers_count ?? 0 }}</span></span>
+  </div>
 
   @if($post->attachment)
     <div style="margin-top:12px">
@@ -30,7 +34,6 @@
 
 <section class="card" style="margin-top:16px;">
   <h3>コメント</h3>
-
   @forelse($post->comments as $comment)
     <div style="border-top:1px solid #eee; padding-top:8px; margin-top:8px;">
       <div class="muted">by {{ $comment->user->name }} ・ {{ $comment->created_at->diffForHumans() }}</div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -4,11 +4,13 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\PostLikeController;
 use App\Http\Controllers\PostCommentController;
+use App\Http\Controllers\UserFollowController;
 
 Route::get('/', fn () => redirect()->route('posts.index'));
 
 Route::resource('posts', PostController::class);
 
 Route::post('posts/{post}/like', PostLikeController::class)->name('posts.like');
-
 Route::post('posts/{post}/comments', PostCommentController::class)->name('posts.comments.store');
+
+Route::post('users/{user}/follow', UserFollowController::class)->name('users.follow');


### PR DESCRIPTION
# feat: フォロー機能（基礎）のトグルを実装（AJAX）

ブランチ: feature/follow-toggle

## 概要
ユーザーのフォロー/解除を非同期でトグルし、フォロワー数を即時反映します。認証未導入の間は既存ユーザーの先頭を擬似的に利用します（後日認証導入で置換）。

## 変更点
- Migration
  - follows テーブルを追加（複合PK: PRIMARY KEY(follower_id, followee_id)、FK: users、created_at のみ）
- Model
  - User::followers() / User::followings() を追加（BelongsToMany, pivot: follows）
- Route
  - POST /users/{user}/follow（name: users.follow）
- Controller
  - UserFollowController を追加（__invoke）
    - 擬似ユーザーIDでトグル
    - レスポンス: { following: bool, count: int }
    - 自分自身の対象は 400（count 同梱）で無視
- View/JS
  - layouts/app.blade.php にフォロートグル処理（fetch + CSRF）を追加
  - posts/show.blade.php にフォローボタンとフォロワー数を表示
- PostController
  - show で著者の followers_count をロード

## 動作確認
1) マイグレーション
```
php src/artisan migrate
```
2) サーバ起動
```
php -S 127.0.0.1:8000 -t src/public
```
3) 確認
- 投稿詳細で「フォローする」をクリック
  - フォロワー数が即時更新し、ボタンが「フォロー解除」にトグル
  - DevTools Network: POST /users/{id}/follow が 200、{ following, count } を返す
- 自分自身を対象にした場合は 400（count は返る）

## レスポンススキーマ（Notion用）
- 成功: { following: boolean, count: number }
- 自分自身: 400 Bad Request + { following: false, count: number, message?: string }
- 未ログイン・ユーザー不在: 401 Unauthorized + { message: string }（暫定）

## DoD
- [x] フォローボタンでトグルできる（即時反映）
- [x] JSON レスポンスのスキーマを定義
- [x] CSRF ヘッダ付き fetch による POST

## 互換性/留意点
- 認証導入後は擬似ユーザー利用を廃止し auth()->id() 固定に変更
- 可視性連動は後日 Policy に集約予定

## ロールバック
```
php src/artisan migrate:rollback --step=1
```