### PR TITLE
検索機能実装

### DIFF
--- a/src/app/Http/Controllers/SearchController.php
+++ b/src/app/Http/Controllers/SearchController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\SearchRequest;
+use App\Models\Post;
+use App\Models\Tag;
+use Illuminate\Support\Facades\DB;
+
+class SearchController extends Controller
+{
+    public function index(SearchRequest $request)
+    {
+        $data = $request->validated();
+        $q    = $data['q']   ?? null;
+        $tag  = $data['tag'] ?? null;
+
+        $query = Post::query()
+            ->select('posts.*')
+            ->with(['user:id,name', 'visibility:id,code', 'attachment'])
+            ->withCount('likedByUsers');
+
+        // 本文 LIKE（ワイルドカードをエスケープ）
+        if ($q !== null && $q !== '') {
+            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $q);
+            $pattern = "%{$escaped}%";
+            $query->whereRaw("posts.body LIKE ? ESCAPE '\\\\'", [$pattern]);
+        }
+
+        // タグ絞り込み（JOIN）
+        if (!empty($tag)) {
+            $query->join('post_tags', 'post_tags.post_id', '=', 'posts.id')
+                  ->where('post_tags.tag_id', $tag)
+                  ->distinct('posts.id');
+        }
+
+        // 空検索は全件表示（方針）
+        $posts = $query->latest('posts.id')->paginate(10)->appends($data);
+
+        $tags = Tag::query()->orderBy('name')->get(['id','name']);
+
+        return view('search.index', [
+            'posts' => $posts,
+            'tags'  => $tags,
+            'q'     => $q,
+            'tag'   => $tag,
+        ]);
+    }
+}

--- a/src/app/Http/Requests/SearchRequest.php
+++ b/src/app/Http/Requests/SearchRequest.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'q'   => ['nullable', 'string', 'max:200'],
+            'tag' => ['nullable', 'integer', 'exists:tags,id'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'q' => 'キーワード',
+            'tag' => 'タグ',
+        ];
+    }
+}

--- a/src/resources/views/search/index.blade.php
+++ b/src/resources/views/search/index.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+
+@php use Illuminate\Support\Str; @endphp
+
+@section('content')
+<h1>検索</h1>
+
+<form method="GET" action="{{ route('search.index') }}" class="card" style="display:flex; gap:12px; align-items:flex-end;">
+  <div class="field" style="flex:1;">
+    <label for="q">キーワード</label><br>
+    <input id="q" type="text" name="q" value="{{ old('q', $q) }}" placeholder="本文を検索">
+    @error('q') <div class="error-text">{{ $message }}</div> @enderror
+  </div>
+
+  <div class="field">
+    <label for="tag">タグ</label><br>
+    <select id="tag" name="tag">
+      <option value="">すべて</option>
+      @foreach($tags as $t)
+        <option value="{{ $t->id }}" @selected(old('tag', $tag)==$t->id)>{{ $t->name }}</option>
+      @endforeach
+    </select>
+    @error('tag') <div class="error-text">{{ $message }}</div> @enderror
+  </div>
+
+  <div class="field">
+    <button type="submit">検索</button>
+  </div>
+</form>
+
+@if($posts->count() === 0)
+  <div class="muted">該当する投稿がありません。</div>
+@endif
+
+@foreach ($posts as $post)
+  <article class="card" style="display:flex;gap:12px;align-items:flex-start;">
+    @if($post->attachment)
+      <img src="{{ asset('storage/'.$post->attachment->path) }}" alt="" style="width:96px;height:96px;object-fit:cover;border:1px solid #ddd;border-radius:8px;">
+    @endif
+    <div style="flex:1">
+      <p>{{ Str::limit($post->body, 160) }}</p>
+      <div class="muted">by {{ $post->user->name ?? 'Unknown' }} ・ {{ $post->visibility->code ?? '-' }}</div>
+      <div style="margin-top:8px">
+        <a href="{{ route('posts.show', $post) }}">詳細</a>
+      </div>
+    </div>
+  </article>
+@endforeach
+
+<div style="margin-top:16px">
+  {{ $posts->links() }}
+</div>
+@endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\PostLikeController;
 use App\Http\Controllers\PostCommentController;
 use App\Http\Controllers\UserFollowController;
+use App\Http\Controllers\SearchController;
 
 Route::get('/', fn () => redirect()->route('posts.index'));
 
@@ -14,3 +15,5 @@ Route::post('posts/{post}/like', PostLikeController::class)->name('posts.like');
 Route::post('posts/{post}/comments', PostCommentController::class)->name('posts.comments.store');
 
 Route::post('users/{user}/follow', UserFollowController::class)->name('users.follow');
+
+Route::get('/search', [SearchController::class, 'index'])->name('search.index');


### PR DESCRIPTION
# feat: 検索（シンプル版）を実装

ブランチ: feature/search-basic

## 概要
投稿をキーワード（本文 LIKE）とタグで絞り込むシンプル検索を追加しました。検索フォームと結果一覧（ページネーション）を提供し、空検索時は全件表示の方針です。

## 変更点
- Route
  - GET /search（name: search.index）
- Request
  - SearchRequest（q: nullable|string|max:200、tag: nullable|exists:tags,id）
- Controller
  - SearchController@index
    - 本文 LIKE 検索（% と _ を ESCAPE）
    - タグ絞り込み（post_tags JOIN + distinct）
    - with(user, visibility, attachment), withCount(likedByUsers)
    - ページネーション時にクエリを引き継ぎ（appends）
- View
  - resources/views/search/index.blade.php
    - 検索フォーム（キーワード/タグ）
    - 結果一覧 + ページネーション
    - バリデーションエラー表示

## 仕様
- 入力検証
  - q: 200文字まで、未入力可
  - tag: tags.id の存在チェック
- 空検索方針
  - q/tag 未指定時は全件表示（最新順）
- LIKE の実装
  - ワイルドカード（%, _）は ESCAPE（\）して部分一致

## 動作確認
1) サーバ起動
```
php -S 127.0.0.1:8000 -t src/public
```
2) ブラウザ操作
- /search を開く
- キーワードのみ、タグのみ、両方指定で検索
- 空検索で全件が表示されること
- ページ遷移してもクエリが保持されること（?q=...&tag=... が維持）

## DoD
- [x] 入力検証あり（不正入力はエラー表示）
- [x] 空検索は全件表示の方針を明記
- [x] 検索フォーム → 結果一覧（ページネーション）まで動作

## メモ（Notion）
- 将来 FullText 候補
  - MySQL FULLTEXT（InnoDB, 日本語はN-gramプラグイン要検討）
  - 外部: Meilisearch / OpenSearch / Algolia
- 最適化
  - 本文全文検索を導入する場合はインデックス設計を見直し
  - タグ検索は post_tags(post_id, tag_id) にインデックス必須（既存対応済み）