### PR TITLE
セキュリティ整備

### DIFF
--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\PostStoreRequest;
 use App\Http\Requests\PostUpdateRequest;
 use App\Models\User; // 追加
 use Illuminate\Support\Facades\Storage;
+use App\Services\AuditLogger;
 
 class PostController extends Controller
 {
@@ -56,14 +57,24 @@ class PostController extends Controller
             $post->tags()->sync($data['tags']);
         }
 
-        // 画像保存（任意）
         if ($request->hasFile('image')) {
-            $path = $request->file('image')->store('attachments', 'public');
-            $post->attachment()->create([
-                'path' => $path,
-                'mime' => $request->file('image')->getClientMimeType(),
-                'size' => $request->file('image')->getSize(),
-            ]);
+            try {
+                $file = $request->file('image');
+                $path = $file->store('attachments', 'public');
+                $post->attachment()->create([
+                    'path' => $path,
+                    'mime' => $file->getClientMimeType(),
+                    'size' => $file->getSize(),
+                ]);
+                AuditLogger::uploadSucceeded($userId, $post->id, $path, $file->getClientMimeType(), (int)$file->getSize(), $request);
+            } catch (\Throwable $e) {
+                AuditLogger::uploadFailed('store_exception', $request, [
+                    'user_id' => $userId,
+                    'post_id' => $post->id,
+                    'error'   => $e->getMessage(),
+                ]);
+                return back()->withInput()->with('error', '画像の保存に失敗しました。');
+            }
         }
 
         return redirect()->route('posts.show', $post)->with('status', 'created');
@@ -120,19 +131,24 @@ class PostController extends Controller
 
         // 新しい画像があれば置き換え
         if ($request->hasFile('image')) {
-            // 旧ファイル削除
-            if ($post->attachment && $post->attachment->path) {
-                Storage::disk('public')->delete($post->attachment->path);
+            try {
+                if ($post->attachment && $post->attachment->path) {
+                    Storage::disk('public')->delete($post->attachment->path);
+                }
+                $file = $request->file('image');
+                $path = $file->store('attachments', 'public');
+                $post->attachment()->updateOrCreate(
+                    [],
+                    ['path' => $path, 'mime' => $file->getClientMimeType(), 'size' => $file->getSize()]
+                );
+                AuditLogger::uploadSucceeded(auth()->id() ?: (\App\Models\User::query()->value('id') ?? null), $post->id, $path, $file->getClientMimeType(), (int)$file->getSize(), $request);
+            } catch (\Throwable $e) {
+                AuditLogger::uploadFailed('update_exception', $request, [
+                    'post_id' => $post->id,
+                    'error'   => $e->getMessage(),
+                ]);
+                return back()->withInput()->with('error', '画像の保存に失敗しました。');
             }
-            $path = $request->file('image')->store('attachments', 'public');
-            $post->attachment()->updateOrCreate(
-                [], // hasOne なので条件なしで1件を更新/作成
-                [
-                    'path' => $path,
-                    'mime' => $request->file('image')->getClientMimeType(),
-                    'size' => $request->file('image')->getSize(),
-                ]
-            );
         }
 
         return redirect()->route('posts.show', $post)->with('status', 'updated');

--- a/src/app/Http/Controllers/PostLikeController.php
+++ b/src/app/Http/Controllers/PostLikeController.php
@@ -6,14 +6,15 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use App\Services\AuditLogger;
 
 class PostLikeController extends Controller
 {
     public function __invoke(Request $request, Post $post): JsonResponse
     {
-        // 認証前の擬似ユーザー（先頭のユーザーを使用）
         $userId = auth()->id() ?: User::query()->value('id');
         if (!$userId) {
+            AuditLogger::likeFailed('no_user', $request, ['post_id' => $post->id]);
             return response()->json(['message' => 'ユーザーが存在しません'], 401);
         }
 
@@ -30,14 +31,15 @@ class PostLikeController extends Controller
             $liked = false;
         } else {
             DB::table('likes')->insert([
-                'user_id' => $userId,
-                'post_id' => $post->id,
+                'user_id'    => $userId,
+                'post_id'    => $post->id,
                 'created_at' => now(),
             ]);
             $liked = true;
         }
 
         $count = DB::table('likes')->where('post_id', $post->id)->count();
+        AuditLogger::likeToggled($userId, $post->id, $liked, $request);
 
         return response()->json(['liked' => $liked, 'count' => $count]);
     }

--- a/src/app/Http/Controllers/UserFollowController.php
+++ b/src/app/Http/Controllers/UserFollowController.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use App\Services\AuditLogger;
 
 class UserFollowController extends Controller
 {
@@ -13,12 +14,14 @@ class UserFollowController extends Controller
     {
         $followerId = auth()->id() ?: User::query()->value('id');
         if (!$followerId) {
+            AuditLogger::followFailed('no_user', $request, ['followee_id' => $user->id]);
             return response()->json(['message' => 'ユーザーが存在しません'], 401);
         }
 
         // 自分自身は不可
         if ((int)$followerId === (int)$user->id) {
             $count = DB::table('follows')->where('followee_id', $user->id)->count();
+            AuditLogger::followFailed('self_target', $request, ['user_id' => $user->id, 'count' => $count]);
             return response()->json(['following' => false, 'count' => $count], 400);
         }
 
@@ -43,6 +46,7 @@ class UserFollowController extends Controller
         }
 
         $count = DB::table('follows')->where('followee_id', $user->id)->count();
+        AuditLogger::followToggled($followerId, $user->id, $following, $request);
 
         return response()->json(['following' => $following, 'count' => $count]);
     }

--- a/src/app/Services/AuditLogger.php
+++ b/src/app/Services/AuditLogger.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class AuditLogger
+{
+    public static function likeToggled(?int $userId, ?int $postId, bool $liked, Request $req): void
+    {
+        Log::info('like.toggled', self::ctx($req) + [
+            'user_id' => $userId,
+            'post_id' => $postId,
+            'liked'   => $liked,
+        ]);
+    }
+
+    public static function likeFailed(string $reason, Request $req, array $extra = []): void
+    {
+        Log::info('like.failed', self::ctx($req) + ['reason' => $reason] + $extra);
+    }
+
+    public static function followToggled(?int $followerId, ?int $followeeId, bool $following, Request $req): void
+    {
+        Log::info('follow.toggled', self::ctx($req) + [
+            'follower_id' => $followerId,
+            'followee_id' => $followeeId,
+            'following'   => $following,
+        ]);
+    }
+
+    public static function followFailed(string $reason, Request $req, array $extra = []): void
+    {
+        Log::info('follow.failed', self::ctx($req) + ['reason' => $reason] + $extra);
+    }
+
+    public static function uploadSucceeded(?int $userId, ?int $postId, string $path, string $mime, int $size, Request $req): void
+    {
+        Log::info('upload.succeeded', self::ctx($req) + [
+            'user_id' => $userId,
+            'post_id' => $postId,
+            'path'    => $path,
+            'mime'    => $mime,
+            'size'    => $size,
+        ]);
+    }
+
+    public static function uploadFailed(string $reason, Request $req, array $extra = []): void
+    {
+        Log::info('upload.failed', self::ctx($req) + ['reason' => $reason] + $extra);
+    }
+
+    private static function ctx(Request $req): array
+    {
+        return [
+            'ip'    => $req->ip(),
+            'ua'    => substr((string) $req->userAgent(), 0, 255),
+            'route' => optional($req->route())->getName(),
+        ];
+    }
+}


### PR DESCRIPTION
# chore: セキュリティ初期整備（XSS/CSRF点検・監査ログ・スロットリング方針）

ブランチ: chore/security-baseline

## 概要
Auth 導入前にできるセキュリティ下地を整備。Blade の出力方針（XSS対策）、全フォーム/AJAX の CSRF 確認、監査ログの一元化（いいね/フォロー/アップロードの成功・失敗）、スロットリング方針のメモを追加。

## 変更点
- 監査ログ
  - AuditLogger サービスを新規追加（like/follow/upload の成功・失敗を INFO 出力）
  - PostLikeController / UserFollowController / PostController(store, update) にログ呼び出しを実装
- CSRF
  - layouts/app.blade.php に CSRF メタタグを明示
  - 既存の fetch に X-CSRF-TOKEN を送信（like/follow は対応済み）
  - 主要フォーム（投稿作成/編集・コメント投稿等）に @csrf を点検（不足あれば追加）
- XSS
  - Blade は原則 {{ }} を使用する方針を明文化
  - {!! !!} を使う場合はサニタイズ済み前提・用途をコメントで明示（棚卸し実施）
- スロットリング（導入メモ）
  - RouteServiceProvider に RateLimiter 定義案を追加（likes/follows/comments/uploads）。現時点ではルート未適用

## ログ出力（例）
- like.toggled / like.failed
- follow.toggled / follow.failed
- upload.succeeded / upload.failed

例:
````text
[info] like.toggled ip=..., ua=..., route=posts.like user_id=1 post_id=10 liked=true
[info] follow.failed ip=..., ua=..., route=users.follow reason=self_target user_id=1 count=3
[info] upload.succeeded ip=..., ua=..., route=posts.store user_id=1 post_id=10 path=attachments/.. mime=image/jpeg size=123456
````

## 動作確認
1) CSRF
- DevTools Network で POST /posts/{id}/like, /users/{id}/follow に X-CSRF-TOKEN ヘッダが付与されていること
- 全フォーム（create/edit/comment）が @csrf を含むこと
2) 監査ログ
- いいね/フォローのトグル、画像アップロード成功・失敗を実行
- storage/logs/laravel.log に INFO が出力されることを確認
3) XSS
- 主要テンプレートが {{ }} 出力であること、{!! !!} は意図的な用途に限定されていることを確認

## DoD
- [x] 主要テンプレートの XSS/CSRF 再点検完了（@csrf・AJAX CSRF ヘッダ）
- [x] 監査ログの出力方針が AuditLogger に一元化
- [x] スロットリングの候補をメモ（後日導入）

## 影響/互換性
- 機能追加のみで既存フローに破壊的変更なし
- ログ量が増えるため本番ではローテーション/マスク方針を別途検討

## ロールバック
- AuditLogger 呼び出しの削除、CSRF メタ/送信の変更を巻き戻し（DBスキーマ変更なし）